### PR TITLE
fix double digits issue with node-sass

### DIFF
--- a/_avalanche.scss
+++ b/_avalanche.scss
@@ -58,7 +58,14 @@ $av-enable-grid-rev:          false !default;
     // Loop through all digits in the numerator and escape individually
     @for $i from 1 through str-length($numerator-as-string) {
       $digit: str-slice($numerator-as-string, $i, $i);
-      $escaped-numerator: $escaped-numerator+\3+$digit;
+
+      @if $i == 1 {
+        $escaped-numerator: $escaped-numerator+\3+$digit;
+      }
+
+      @else {
+        $escaped-numerator: $escaped-numerator+' '+$digit;
+      }
     }
 
     @return $escaped-numerator;


### PR DESCRIPTION
the escaping of the secondary digit was breaking the class selection. this solves the issue, for example `10/12`